### PR TITLE
Enemy EXP changes

### DIFF
--- a/Enemy.luau
+++ b/Enemy.luau
@@ -75,7 +75,7 @@ return {
 		health = 600,
 		damage = 50,
 		walkspeed = 20,
-		xp = 10,
+		xp = 15,
 
 		cash_earned = {75, 125},
 
@@ -95,7 +95,7 @@ return {
 		health = 20,
 		damage = 60,
 		walkspeed = 30,
-		xp = 1,
+		xp = 3,
 
 		cash_earned = {10, 20},
 
@@ -122,7 +122,7 @@ return {
 		health = 150,
 		damage = 20,
 		walkspeed = 6,
-		xp = 3,
+		xp = 5,
 
 		cash_earned = {100, 150},
 
@@ -148,7 +148,7 @@ return {
 		health = 1000,
 		damage = 75,
 		walkspeed = 20,
-		xp = 20,
+		xp = 30,
 
 		cash_earned = {200, 250},
 		


### PR DESCRIPTION
- Dire Wolf 
  - Exp 10 > 15
- King Adelaid 
  - Exp 20 > 30

Bosses should give WAY more exp, because they are difficult to fight (without cheese) and take way longer to kill than basic enemies. (I would even argue the exp gain should be even more than what I proposed)

- Bluesteel Mite 
  - Exp 1 > 3

Mites are very easy to kill, however they are also very easy to die to, I believe they should give the same EXP as wolves.

- Bluesteel Golem
  - Exp 4 > 5

Golems are by far the easiest dungeon enemy to farm if you cannot one shot mites, they used to give 8 exp (until foshes changed it to 4) but I believe it should be 5, so people dont continue grinding wolves instead of golems for their exp.