### PR TITLE
Update Enemy.luau

### DIFF
--- a/Enemy.luau
+++ b/Enemy.luau
@@ -75,7 +75,7 @@ return {
 		health = 600,
 		damage = 50,
 		walkspeed = 20,
-		xp = 10,
+		xp = 15,
 
 		cash_earned = {75, 125},
 
@@ -92,8 +92,8 @@ return {
 	},
 	{
 		name = "Bluesteel Mite",
-		health = 40,
-		damage = 25,
+		health = 20,
+		damage = 60,
 		walkspeed = 30,
 		xp = 2,
 
@@ -120,9 +120,9 @@ return {
 	{
 		name = "Bluesteel Golem",
 		health = 150,
-		damage = 40,
+		damage = 30,
 		walkspeed = 6,
-		xp = 3,
+		xp = 4,
 
 		cash_earned = {100, 150},
 
@@ -147,10 +147,10 @@ return {
 		name = "King Adelaid",
 		health = 1000,
 		damage = 75,
-		walkspeed = 20,
-		xp = 20,
+		walkspeed = 18,
+		xp = 25,
 
-		cash_earned = {200, 250},
+		cash_earned = {425, 525},
 		
 		floor_unlock = 3,
 		model = script.Adelaid,


### PR DESCRIPTION
[Direwolf]
+ XP gain increased 10 -> 15

[Bluesteel Mite]
+ XP gain increased 1 -> 2

[Bluesteel Golem]
*Golems are very slow but did too little damage.*
+ Damage increased 20 -> 30
+ XP gain increased 3 -> 4

[King Adelaid]
*Being perhaps the final boss of floor 1, players deserve more rewards for defeating him to help them progress into the next floor. Once the cheesy "mechanics" are removed in the combat overhaul, this walkspeed change will make more sense.*
- Walkspeed decreased 20 -> 18
- XP gain increased 20 -> 25
- Cash earned increased (200, 250) -> (425, 525)